### PR TITLE
fix(firestore-redux): export all actions & use memoize into selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ An offline-first + real-time database using Firestore + Redux.
 import { initializeApp } from "firebase/app";
 import firestoreRedux from "@dreamworld/firestore-redux";
 import { store } from "./store.js"; // This is store.js PATH of your application where store is created using `createStore` So replace it if required.
-const firebaseConfig = {}; /* Firebase Configurations. e.g. { "apiKey": "AIzaSyAD9RzBEZ_pzZomgIbyIHo0No4PoFDm2Zc", "authDomain": "friendlyeats-d6aa1.firebaseapp.com", "projectId": "friendlyeats-d6aa1" } */
-const readPollingConfig = { timeout: 30000 , maxAttempts: 20 }; // timeout is in milliseconds.
+const firebaseConfig =
+  {}; /* Firebase Configurations. e.g. { "apiKey": "AIzaSyAD9RzBEZ_pzZomgIbyIHo0No4PoFDm2Zc", "authDomain": "friendlyeats-d6aa1.firebaseapp.com", "projectId": "friendlyeats-d6aa1" } */
+const readPollingConfig = { timeout: 30000, maxAttempts: 20 }; // timeout is in milliseconds.
 const firebaseApp = initializeApp(firebaseConfig);
 firestoreRedux.init({ store, firebaseApp, readPollingConfig });
 ```
@@ -54,13 +55,10 @@ try {
 }
 
 // Result can be retrieved from the redux state directly through selector factory.
-const docsByQuerySelector =
-  firestoreRedux.selectors.docsByQueryFactory(queryId, collection);
-const docs = docsByQuerySelector(state); // [{id, ...}, {id, ...}, ...]
+const docsByQuery = firestoreRedux.selectors.docsByQuery({ state, queryId }); // [{id, ...}, {id, ...}, ...]
 
 // Get all documents for given collection.
-const allDocsSelector = firestoreRedux.selectors.allDocsFactory(collection);
-const allDocs = allDocsSelector(state); // [{id, ...}, {id, ...}, ...]
+const allDocs = firestoreRedux.selectors.allDocs({ state, collection }); // [{id, ...}, {id, ...}, ...]
 ```
 
 ### Read document by it's ID.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "lodash-es": "^4.17.21",
     "proxy-memoize": "^0.3.8",
     "redux": "^4.1.2",
-    "reselect": "^4.1.5",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/src/firestore-redux.js
+++ b/src/firestore-redux.js
@@ -183,10 +183,10 @@ class FirestoreRedux {
    * @param {String} requesterId Requester Id.
    */
   cancelQueryByRequester(requesterId) {
-    const liveQueries = _selectors.liveQueriesByRequester(
-      this.store.getState(),
-      requesterId
-    );
+    const liveQueries = _selectors.liveQueriesByRequester({
+      state: this.store.getState(),
+      requesterId,
+    });
     forEach(liveQueries, (id) => {
       this.__cancel(id);
     });
@@ -224,3 +224,10 @@ const firestoreRedux = new FirestoreRedux();
 firestoreRedux.selectors = _selectors;
 export default firestoreRedux;
 export const selectors = _selectors;
+export const init = firestoreRedux.init;
+export const query = firestoreRedux.query;
+export const getDocById = firestoreRedux.getDocById;
+export const save = firestoreRedux.save;
+export const deleteDoc = firestoreRedux.delete;
+export const cancelQuery = firestoreRedux.cancelQuery;
+export const cancelQueryByRequester = firestoreRedux.cancelQueryByRequester;

--- a/src/query.js
+++ b/src/query.js
@@ -176,10 +176,10 @@ class Query {
           status: "CLOSED",
         });
 
-        const result = selectors.docsByQueryFactory(id, collection)(
-          this.store.getState(),
-          collection
-        );
+        const result = selectors.docsByQuery({
+          state: this.store.getState(),
+          queryId: id,
+        });
         this._resolve(result);
         if (this._criteria.waitTillSucceed) {
           this._retryResolve(result);
@@ -249,10 +249,10 @@ class Query {
             status: "LIVE",
           });
           if (!queryResolved) {
-            const result = selectors.docsByQueryFactory(
-              id,
-              collection
-            )(this.store.getState());
+            const result = selectors.docsByQuery({
+              state: this.store.getState(),
+              queryId: id,
+            });
             this._resolve(result);
             if (this._criteria.waitTillSucceed) {
               this._retryResolve(result);
@@ -419,7 +419,7 @@ class Query {
           timeout: this.pollingConfig.timeout,
           maxAttempts: this.pollingConfig.maxAttempts,
           factor: 2,
-          maxDelay: 1000
+          maxDelay: 1000,
         }
       );
     } catch (error) {

--- a/wiki/user-reference-guide.md
+++ b/wiki/user-reference-guide.md
@@ -14,7 +14,7 @@ firestoreRedux.init(store, firebaseApp);
 
 - `store (Object)` Redux Store. It is mandatory.
 - `firebaseApp (Object)` Firebase app. It is optional.
-- `readPollingConfig` Configurations for waiting query. This is ignored when `waitTillSucceed` query criteria is not `true`. Default is `{ timeout: 30000, maxAttempts: 20 }`. 
+- `readPollingConfig` Configurations for waiting query. This is ignored when `waitTillSucceed` query criteria is not `true`. Default is `{ timeout: 30000, maxAttempts: 20 }`.
 
 ##### returns
 
@@ -193,34 +193,35 @@ const doc = firestoreRedux.selectors.doc(state, collection, docId);
 
 - `(Object)` e.g. `{ id, firstName, lastName, profilePic }`
 
-### `firestoreRedux.selectors.allDocsFactory`
+### `firestoreRedux.selectors.allDocs`
 
 Gets all documents of the given collection ID.
 
 ```JS
-const docs = firestoreRedux.selectors.allDocsFactory(collection)(state);
+const docs = firestoreRedux.selectors.allDocs({state, collection});
 ```
 
 ##### Arguments
 
+- `state (Object)` Redux state.
 - `collection (String)` Collection ID.
 
 ##### returns
 
 - `(Array)` e.g. `[ { id, firstName, lastName, profilePic },{ id, firstName, lastName, profilePic }, ... ]`
 
-### `firestoreRedux.selectors.docsByQueryFactory`
+### `firestoreRedux.selectors.docsByQuery`
 
 Gets documents of given collection, based the query result of given queryId.
 
 ```JS
-const docs = firestoreRedux.selectors.docsByQueryFactory(queryId, collection)(state);
+const docs = firestoreRedux.selectors.docsByQuery({state, queryId});
 ```
 
 ##### Arguments
 
+- `state (Object)` Redux state.
 - `queryId (String)` Query ID, from whose documents will be returned.
-- `collection (String)` Collection ID.
 
 ##### returns
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2158,11 +2158,6 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
-reselect@^4.1.5:
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.5.tgz#852c361247198da6756d07d9296c2b51eddb79f6"
-  integrity sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ==
-
 resolve-path@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/resolve-path/-/resolve-path-1.4.0.tgz#c4bda9f5efb2fce65247873ab36bb4d834fe16f7"


### PR DESCRIPTION
- Use memoize for better usability & performance.
- Export all individual actions of the library.